### PR TITLE
Justering av max tillatt CPU-forbruk

### DIFF
--- a/nais-dev.json
+++ b/nais-dev.json
@@ -38,7 +38,7 @@
     ],
     "resources": {
       "limits": {
-        "cpu": "500m",
+        "cpu": "3",
         "memory": "768Mi"
       },
       "requests": {

--- a/nais-prod.json
+++ b/nais-prod.json
@@ -38,7 +38,7 @@
     ],
     "resources": {
       "limits": {
-        "cpu": "500m",
+        "cpu": "3",
         "memory": "768Mi"
       },
       "requests": {


### PR DESCRIPTION
Justert opp maks CPU til 3 CPU-er, i stede for 0.5 CPU-er. Dette er gjort for at appen ikke skal kjøre veldig sakte.